### PR TITLE
Jackd support for the GUI version. 

### DIFF
--- a/compile
+++ b/compile
@@ -1,0 +1,1 @@
+/usr/share/automake-1.16/compile

--- a/compile
+++ b/compile
@@ -1,1 +1,0 @@
-/usr/share/automake-1.16/compile

--- a/src/glassplayergui/glassplayergui.cpp
+++ b/src/glassplayergui/glassplayergui.cpp
@@ -35,14 +35,25 @@ MainWidget::MainWidget(QWidget *parent)
 {
   gui_player_process=NULL;
   gui_logo_process=NULL;
+  jackdArgs=QStringList();
 
   CmdSwitch *cmd=new CmdSwitch("glassplayergui",GLASSPLAYERGUI_USAGE);
   if(cmd->keys()>0) {
     for(unsigned i=0;i<(cmd->keys()-1);i++) {
-      if(!cmd->processed(i)) {
-	QMessageBox::critical(this,"GlassPlayer - "+tr("Error"),
-			      tr("Unknown argument")+" \""+cmd->key(i)+"\".");
-	exit(256);
+      if(cmd->key(i)=="--audio-device") {
+        jackdArgs.push_back("--audio-device=" + cmd->value(i));
+        cmd->setProcessed(i,false);
+      } else if(cmd->key(i)=="--jack-server-name") {
+        jackdArgs.push_back("--jack-server-name=" + cmd->value(i));
+        cmd->setProcessed(i,false);
+      } else if(cmd->key(i)=="--jack-client-name") {
+        jackdArgs.push_back("--jack-client-name=" + cmd->value(i));
+        jackdClientName = cmd->value(i);
+        cmd->setProcessed(i,false);
+      } else if (!cmd->processed(i)) {
+	      QMessageBox::critical(this,"GlassPlayer - "+tr("Error"),
+			    tr("Unknown argument")+" \""+cmd->key(i)+"\".");
+          exit(256);
       }
     }
     gui_url=cmd->key(cmd->keys()-1);
@@ -55,14 +66,18 @@ MainWidget::MainWidget(QWidget *parent)
   QFont bold_font=font();
   bold_font.setWeight(QFont::Bold);
 
-  setWindowTitle(QString("GlassPlayer - v")+VERSION);
+  if (jackdClientName.isNull()) {
+    setWindowTitle(QString("GlassPlayer - v")+VERSION);
+  } else {
+    setWindowTitle(jackdClientName+QString(" @ GlassPlayer - v")+VERSION);
+  }
 
   gui_stats_dialog=new StatsDialog(this);
 
   //
   // Metadata Title
   //
-  gui_title_text=new QLabel(tr("The GlassPlayer"),this);
+  gui_title_text=new QLabel(tr("Stream metadata"),this);
   gui_title_text->setFont(title_font);
 
   //
@@ -110,7 +125,7 @@ MainWidget::MainWidget(QWidget *parent)
 	  this,SLOT(newJsonDocumentData(const QJsonDocument &)));
 
   if(!gui_url.isEmpty()) {
-    processStart(gui_url);
+    processStart(gui_url, jackdArgs);
   }
 
   setMinimumSize(sizeHint());
@@ -136,8 +151,7 @@ void MainWidget::showStatsData()
   }
 }
 
-
-void MainWidget::processStart(const QString &url)
+void MainWidget::processStart(const QString &url, const QStringList &jackdArgs)
 {
   QStringList args;
 
@@ -145,6 +159,12 @@ void MainWidget::processStart(const QString &url)
   args.push_back("--meter-data");
   args.push_back("--metadata-out");
   args.push_back("--stats-out");
+  if (!jackdArgs.isEmpty()){
+    for ( const auto& jackdArg : jackdArgs  )
+    {
+      args.push_back(jackdArg);
+    }
+  }
   args.push_back(url);
   if(gui_player_process!=NULL) {
     delete gui_player_process;

--- a/src/glassplayergui/glassplayergui.h
+++ b/src/glassplayergui/glassplayergui.h
@@ -45,7 +45,7 @@ class MainWidget : public QMainWindow
 
  private slots:
   void showStatsData();
-  void processStart(const QString &url);
+  void processStart(const QString &url, const QStringList &jackdArgs);
   void processReadyReadData();
   void processFinishedData(int exit_code,QProcess::ExitStatus status);
   void processErrorData(QProcess::ProcessError err);
@@ -70,6 +70,8 @@ class MainWidget : public QMainWindow
   JsonParser *gui_json_parser;
   QStringList gui_stats_list;
   QString gui_url;
+  QStringList jackdArgs;
+  QString jackdClientName;  
   PlayMeter *gui_meters[MAX_AUDIO_CHANNELS];
   StatsDialog *gui_stats_dialog;
   QPushButton *gui_stats_button;


### PR DESCRIPTION
Not sure if I'm doing this right... I'm not used to PR.

But the code changes have been tested for several months now... and I've had no issues at all. In reality there's nothing very interesting on the changes: 

- Basically, I've added the ability to (optionally) pass the glassplayer CLI params required to connect to jack, to the glassplayer-gui binary call, so it can in turn pass them when spawning the player.
- When passing the jack client name, the resulting window title  prepends the jack client name to the tittle, so it is easier to distiguish between multiple glassplayer-gui instances running as several, independent, jack clients.
- I also changed the 'Metadata tittle' window title, according to the comment, because it was confusing to me... just cosmetic

Probably not the best coding practices, and I guess any changes should be documented on the man pages... but the functionality is very very useful to me. I missed very very much jackd on glassplayer-gui, while glassplayer, glasscoder and, overall, the rivendell ecosystem is fully jackd-friendly.

Best regards.